### PR TITLE
Fixed grace period

### DIFF
--- a/src/SurvivalGamesV3/SurvivalGamesV3.php
+++ b/src/SurvivalGamesV3/SurvivalGamesV3.php
@@ -176,7 +176,7 @@ class SurvivalGamesV3 extends PluginBase implements Listener {
 		{
 			$config = new Config($this->getDataFolder() . "/config.yml", Config::YAML);
 			$sofar = $config->get($level . "StartTime");
-			if($sofar > 15)
+			if($sofar > 75)
 			{
 				if($player instanceof Player){
 				$event->setCancelled(true);


### PR DESCRIPTION
For some reason it allows you to hit a player when the game starts I believe it's because it starts the grace when the count down starts and only last for 15sec this commit fixes this it adds 15sec after the game starts + the 60sec waiting time